### PR TITLE
Change the Tracked checkbox on the data entry page to a button

### DIFF
--- a/app/components/tracker/EntryInput.tsx
+++ b/app/components/tracker/EntryInput.tsx
@@ -1,7 +1,6 @@
-import { Plus, Delete } from "lucide-react";
+import { Plus, X } from "lucide-react";
 import { useState } from "react";
 import { Button } from "~/components/ui/button";
-import { Checkbox } from "~/components/ui/checkbox";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { formatDateString } from "~/lib/dates";
@@ -85,7 +84,7 @@ export function EntryInput({
               disabled={entryLoading}
               className="w-full"
             >
-              <Delete /> Remove Tracking
+              <X /> Mark as Untracked
             </Button>
           ) : (
             <>
@@ -111,7 +110,7 @@ export function EntryInput({
                 disabled={entryLoading}
                 className="w-full"
               >
-                <Plus /> Set as Tracked
+                <Plus /> Mark as Tracked
               </Button>
             </>
           )}


### PR DESCRIPTION
Implements #9:
- change checkbox to button
- move comments field before button
- hide comments field if data is already tracked for selected day