### PR TITLE
fix streak calculations and unify stat logic

### DIFF
--- a/app/routes/monthly-recap.tsx
+++ b/app/routes/monthly-recap.tsx
@@ -109,11 +109,11 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
       (entry) => entry.date >= start && entry.date <= end
     );
 
-    // Calculate all stats in a single pass
+    // Calculate period-specific stats
     const fromDate = new Date(year, month, 1);
     const toDate = endOfMonth(fromDate);
 
-    const calculatedStats = calculateUnifiedStats(
+    const periodStats = calculateUnifiedStats(
       entries,
       { fromDate, toDate },
       tracker.goal,
@@ -124,23 +124,43 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
         includeDaysMissed: true,
         includePercentageDaysTracked: true,
         includeBestDay: true,
-        includeStreaks: true,
         includeTodayGoalMet: true,
       }
     );
 
+    // Calculate streaks using ALL entries for full streak history
+    const firstEntryDate =
+      allEntries.length > 0
+        ? new Date(
+            Math.min(...allEntries.map((e) => new Date(e.date).getTime()))
+          )
+        : fromDate;
+
+    const hasGoal = tracker.goal && tracker.goal > 0;
+
+    const streakStats = calculateUnifiedStats(
+      allEntries,
+      { fromDate: firstEntryDate, toDate: new Date() },
+      tracker.goal,
+      hasGoal ? { includeGoalStreaks: true } : { includeStreaks: true }
+    );
+
     stats.push({
       tracker,
-      total: calculatedStats.total ?? 0,
-      daysTracked: calculatedStats.daysTracked ?? 0,
-      daysMissed: calculatedStats.daysMissed ?? 0,
-      percentageDaysTracked: calculatedStats.percentageDaysTracked ?? 0,
-      isTodayGoalMet: calculatedStats.isTodayGoalMet ?? false,
+      total: periodStats.total ?? 0,
+      daysTracked: periodStats.daysTracked ?? 0,
+      daysMissed: periodStats.daysMissed ?? 0,
+      percentageDaysTracked: periodStats.percentageDaysTracked ?? 0,
+      isTodayGoalMet: periodStats.isTodayGoalMet ?? false,
       isCurrentMonth,
-      average: calculatedStats.average ?? 0,
-      bestDay: calculatedStats.bestDay ?? null,
-      longestStreak: calculatedStats.longestStreak ?? 0,
-      currentStreak: calculatedStats.currentStreak ?? 0,
+      average: periodStats.average ?? 0,
+      bestDay: periodStats.bestDay ?? null,
+      longestStreak: hasGoal
+        ? (streakStats.longestGoalStreak ?? 0)
+        : (streakStats.longestStreak ?? 0),
+      currentStreak: hasGoal
+        ? (streakStats.currentGoalStreak ?? 0)
+        : (streakStats.currentStreak ?? 0),
       entries,
     });
   }
@@ -469,14 +489,18 @@ export default function MonthlyRecap() {
                     )}
 
                     <div className="bg-black/20 rounded-xl p-4">
-                      <div className="text-3xl font-bold">{stat.longestStreak}</div>
+                      <div className="text-3xl font-bold">
+                        {stat.longestStreak}
+                      </div>
                       <div className="text-sm opacity-90 mt-1">
                         Longest Streak
                       </div>
                     </div>
 
                     <div className="bg-black/20 rounded-xl p-4">
-                      <div className="text-3xl font-bold">{stat.currentStreak}</div>
+                      <div className="text-3xl font-bold">
+                        {stat.currentStreak}
+                      </div>
                       <div className="text-sm opacity-90 mt-1">
                         Current Streak
                       </div>

--- a/app/routes/monthly-recap.tsx
+++ b/app/routes/monthly-recap.tsx
@@ -31,7 +31,7 @@ import {
   EmptyTitle,
   EmptyDescription,
 } from "~/components/ui/empty";
-import { endOfMonth, isSameDay } from "date-fns";
+import { endOfMonth, endOfToday } from "date-fns";
 import { formatDateString } from "~/lib/dates";
 
 type Entry = {
@@ -140,7 +140,7 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
 
     const streakStats = calculateUnifiedStats(
       allEntries,
-      { fromDate: firstEntryDate, toDate: new Date() },
+      { fromDate: firstEntryDate, toDate: endOfToday() },
       tracker.goal,
       hasGoal ? { includeGoalStreaks: true } : { includeStreaks: true }
     );


### PR DESCRIPTION
- Resolve #58 & #70
- Refactor streak and goal streak calculations in calculateStats to ensure current streaks end at today and only count consecutive days
- Update monthly-recap and tracker stats routes to separate period-specific stats from global streak stats, ensuring accurate display of current and longest streaks for both goal and non-goal trackers.