### PR TITLE
Add color selector for trackers

### DIFF
--- a/app/components/ui/color-input.tsx
+++ b/app/components/ui/color-input.tsx
@@ -1,0 +1,154 @@
+import * as React from "react";
+
+import { cn } from "~/lib/utils";
+import { Input } from "~/components/ui/input";
+import { Button } from "~/components/ui/button";
+
+const DEFAULT_COLORS = [
+  "#E11D48",
+  "#EF4444",
+  "#F97316",
+  "#F59E0B",
+  "#EAB308",
+  "#84CC16",
+  "#22C55E",
+  "#14B8A6",
+  "#06B6D4",
+  "#3B82F6",
+  "#6366F1",
+  "#8B5CF6",
+  "#EC4899",
+];
+
+type ColorInputProps = {
+  value?: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  name?: string;
+  id?: string;
+  className?: string;
+  presets?: string[];
+  fallbackColor?: string;
+  allowEmpty?: boolean;
+};
+
+const normalizeHex = (value: string): string | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  const withHash = trimmed.startsWith("#") ? trimmed : `#${trimmed}`;
+  if (/^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/.test(withHash)) {
+    return withHash.toUpperCase();
+  }
+  return null;
+};
+
+function ColorInput({
+  value,
+  onChange,
+  disabled = false,
+  name,
+  id,
+  className,
+  presets = DEFAULT_COLORS,
+  fallbackColor = "#3B82F6",
+  allowEmpty = true,
+}: ColorInputProps) {
+  const normalized = normalizeHex(value || "");
+  const [textValue, setTextValue] = React.useState(
+    normalized === null ? "" : normalized
+  );
+
+  React.useEffect(() => {
+    if (normalized === null) return;
+    setTextValue(normalized);
+  }, [normalized]);
+
+  const displayColor = normalized || fallbackColor;
+
+  const handleTextChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const next = event.target.value;
+    setTextValue(next);
+
+    const parsed = normalizeHex(next);
+    if (parsed === "") {
+      if (allowEmpty) onChange("");
+      return;
+    }
+
+    if (parsed) {
+      onChange(parsed);
+    }
+  };
+
+  const handlePresetClick = (preset: string) => {
+    onChange(preset.toUpperCase());
+  };
+
+  const handleClear = () => {
+    if (!allowEmpty) return;
+    onChange("");
+  };
+
+  return (
+    <div className={cn("grid gap-2", className)}>
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative h-9 w-9">
+          <div
+            className={cn(
+              "h-9 w-9 rounded-md border shadow-xs",
+              disabled && "opacity-50"
+            )}
+            style={{ backgroundColor: displayColor }}
+          />
+          <input
+            type="color"
+            value={displayColor}
+            onChange={(event) => onChange(event.target.value.toUpperCase())}
+            disabled={disabled}
+            className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+            aria-label="Choose color"
+          />
+        </div>
+        <Input
+          id={id}
+          name={name}
+          value={textValue}
+          onChange={handleTextChange}
+          disabled={disabled}
+          placeholder="#RRGGBB"
+          className="w-28 font-mono uppercase grow"
+        />
+        {allowEmpty && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleClear}
+            disabled={disabled || !textValue}
+          >
+            Clear
+          </Button>
+        )}
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {presets.map((preset) => (
+          <button
+            key={preset}
+            type="button"
+            className={cn(
+              "h-6 w-6 rounded-full border shadow-xs transition-transform",
+              "hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+              disabled && "cursor-not-allowed opacity-50"
+            )}
+            style={{ backgroundColor: preset }}
+            onClick={() => handlePresetClick(preset)}
+            disabled={disabled}
+            aria-label={`Set color to ${preset}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export { ColorInput };

--- a/app/lib/trackers.ts
+++ b/app/lib/trackers.ts
@@ -60,6 +60,7 @@ export type Tracker = {
   title: string;
   type: TrackerType;
   isNumber: boolean;
+  color?: string;
   values: {
     [dateString: string]: number;
   };

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -304,13 +304,23 @@ export default function Home() {
                       prefetch="viewport"
                       className="flex-1 min-h-full font-medium p-2 relative transition-colors hover:bg-accent flex flex-col justify-center max-w-full"
                     >
-                      <span
-                        className={clsx("text-xs line-clamp-2 break-words", {
-                          "ml-8": tracker.parentId,
-                        })}
+                      <div
+                        className={clsx(
+                          "flex items-center gap-2 text-xs line-clamp-2 break-words",
+                          {
+                            "ml-8": tracker.parentId,
+                          }
+                        )}
                       >
-                        {tracker.title}
-                      </span>
+                        {tracker.color && (
+                          <span
+                            className="h-2.5 w-2.5 rounded-full shrink-0"
+                            style={{ backgroundColor: tracker.color }}
+                            aria-hidden="true"
+                          />
+                        )}
+                        <span>{tracker.title}</span>
+                      </div>
                     </Link>
                   </div>
                   <div

--- a/app/routes/new-tracker.tsx
+++ b/app/routes/new-tracker.tsx
@@ -303,11 +303,6 @@ export default function NewTrackerPage() {
                 disabled={!isColorEnabled}
                 fallbackColor="#3B82F6"
               />
-              {/* <div className="text-sm text-muted-foreground">
-                {isColorEnabled && state.color
-                  ? state.color.toUpperCase()
-                  : "No color selected"}
-              </div> */}
             </div>
           </div>
           <div className="grid items-center gap-3">

--- a/app/routes/new-tracker.tsx
+++ b/app/routes/new-tracker.tsx
@@ -38,6 +38,7 @@ import {
   toStoredValue,
   getInputStep,
 } from "~/lib/number-conversions";
+import { ColorInput } from "~/components/ui/color-input";
 
 export async function clientLoader({ request }: ClientLoaderFunctionArgs) {
   try {
@@ -56,6 +57,7 @@ export async function clientAction({ request }: ClientActionFunctionArgs) {
   const goalStr = formData.get("goal") as string;
   const parentId = formData.get("parentId") as string;
   const isHidden = formData.get("isHidden") === "true";
+  const color = (formData.get("color") as string) || "";
 
   // Validation
   if (!title || !title.trim()) {
@@ -69,6 +71,7 @@ export async function clientAction({ request }: ClientActionFunctionArgs) {
       isNumber: type !== "checkbox",
       ...(goalStr && parseFloat(goalStr) > 0 && { goal: parseFloat(goalStr) }),
       ...(parentId && parentId !== "none" && { parentId }),
+      ...(color.trim() && { color: color.trim() }),
       isHidden,
     };
 
@@ -101,6 +104,7 @@ interface TrackerFormData {
   type: TrackerType;
   goal?: number; // Stored as integer (e.g., milliliters for liters)
   parentId?: string;
+  color?: string;
   isHidden: boolean;
 }
 
@@ -110,6 +114,7 @@ export default function NewTrackerPage() {
   const actionData = useActionData<typeof clientAction>();
   const [isCheckboxTypeSelected, setIsCheckboxTypeSelected] = useState(false);
   const [isTypeDisabled, setIsTypeDisabled] = useState(false);
+  const [isColorEnabled, setIsColorEnabled] = useState(false);
 
   const { state, errors, updateField, setFieldError, clearErrors, setState } =
     useFormState<TrackerFormData>({
@@ -117,6 +122,7 @@ export default function NewTrackerPage() {
       type: "none",
       goal: undefined,
       parentId: undefined,
+      color: undefined,
       isHidden: false,
     });
 
@@ -263,6 +269,47 @@ export default function NewTrackerPage() {
               />
             </div>
           )}
+
+          <div className="grid items-center gap-3">
+            <Label htmlFor="trackerColor">Tracker color (optional)</Label>
+            <div className="flex items-center gap-3">
+              <Checkbox
+                id="trackerColorEnabled"
+                checked={isColorEnabled}
+                onCheckedChange={(checked) => {
+                  const isEnabled = checked === true;
+                  setIsColorEnabled(isEnabled);
+                  if (isEnabled && !state.color) {
+                    updateField("color", "#3b82f6");
+                  }
+                  if (!isEnabled) {
+                    updateField("color", "");
+                  }
+                }}
+              />
+              <Label
+                htmlFor="trackerColorEnabled"
+                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+              >
+                Use custom color
+              </Label>
+            </div>
+            <div className="flex items-center gap-3">
+              <ColorInput
+                id="trackerColor"
+                name="color"
+                value={state.color || ""}
+                onChange={(value) => updateField("color", value)}
+                disabled={!isColorEnabled}
+                fallbackColor="#3B82F6"
+              />
+              {/* <div className="text-sm text-muted-foreground">
+                {isColorEnabled && state.color
+                  ? state.color.toUpperCase()
+                  : "No color selected"}
+              </div> */}
+            </div>
+          </div>
           <div className="grid items-center gap-3">
             <Label htmlFor="parentTracker">Parent tracker (optional)</Label>
             <Select

--- a/app/routes/t.$trackerId.(layout).edit.tsx
+++ b/app/routes/t.$trackerId.(layout).edit.tsx
@@ -43,6 +43,7 @@ import {
   toStoredValue,
   getInputStep,
 } from "~/lib/number-conversions";
+import { ColorInput } from "~/components/ui/color-input";
 
 export async function clientLoader({ params }: ClientLoaderFunctionArgs) {
   const trackerId = params.trackerId;
@@ -89,6 +90,7 @@ export async function clientAction({
       const type = formData.get("type") as TrackerType;
       const goalStr = formData.get("goal") as string;
       const isHidden = formData.get("isHidden") === "true";
+      const color = (formData.get("color") as string) || "";
 
       if (!title || !title.trim()) {
         return { error: { title: "Tracker name is required" } };
@@ -106,6 +108,7 @@ export async function clientAction({
         isNumber: type !== "checkbox",
         goal:
           goalStr && parseFloat(goalStr) > 0 ? parseFloat(goalStr) : undefined,
+        color: color.trim() ? color.trim() : undefined,
         isHidden,
       };
 
@@ -137,6 +140,7 @@ interface TrackerFormData {
   title: string;
   type: TrackerType;
   goal?: number;
+  color?: string;
   isHidden: boolean;
 }
 
@@ -148,12 +152,14 @@ export default function TrackerEditPage() {
   const [isCheckboxTypeSelected, setIsCheckboxTypeSelected] = useState(
     tracker.type === "checkbox"
   );
+  const [isColorEnabled, setIsColorEnabled] = useState(Boolean(tracker.color));
 
   const { state, errors, updateField, setFieldError, clearErrors, setState } =
     useFormState<TrackerFormData>({
       title: tracker.title,
       type: tracker.type,
       goal: tracker.goal,
+      color: tracker.color,
       isHidden: tracker.isHidden || false,
     });
 
@@ -308,6 +314,48 @@ export default function TrackerEditPage() {
               />
             </div>
           )}
+
+          <div className="grid items-center gap-3">
+            <Label htmlFor="trackerColor">Tracker color (optional)</Label>
+            <div className="flex items-center gap-3">
+              <Checkbox
+                id="trackerColorEnabled"
+                checked={isColorEnabled}
+                onCheckedChange={(checked) => {
+                  const isEnabled = checked === true;
+                  setIsColorEnabled(isEnabled);
+                  if (isEnabled && !state.color) {
+                    updateField("color", "#3b82f6");
+                  }
+                  if (!isEnabled) {
+                    updateField("color", "");
+                  }
+                }}
+              />
+              <Label
+                htmlFor="trackerColorEnabled"
+                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+              >
+                Use custom color
+              </Label>
+            </div>
+            <div className="flex items-center gap-3">
+              <ColorInput
+                id="trackerColor"
+                name="color"
+                value={state.color || ""}
+                onChange={(value) => updateField("color", value)}
+                disabled={!isColorEnabled}
+                fallbackColor="#3B82F6"
+                className="w-full"
+              />
+              {/* <div className="text-sm text-muted-foreground">
+                {isColorEnabled && state.color
+                  ? state.color.toUpperCase()
+                  : "No color selected"}
+              </div> */}
+            </div>
+          </div>
 
           <div className="flex items-center gap-3">
             <Checkbox

--- a/app/routes/t.$trackerId.(layout).edit.tsx
+++ b/app/routes/t.$trackerId.(layout).edit.tsx
@@ -349,11 +349,6 @@ export default function TrackerEditPage() {
                 fallbackColor="#3B82F6"
                 className="w-full"
               />
-              {/* <div className="text-sm text-muted-foreground">
-                {isColorEnabled && state.color
-                  ? state.color.toUpperCase()
-                  : "No color selected"}
-              </div> */}
             </div>
           </div>
 


### PR DESCRIPTION
Introduce a reusable ColorInput component (picker, hex input, presets, clear) and integrate it into the tracker creation and edit flows. Update the Tracker type to include an optional color field, persist/validate the color in client actions, and normalize hex values. Show a color swatch next to tracker titles in the index list and add a toggle to enable/disable custom colors in the new/edit forms. Uses a fallback color (#3B82F6) when none is set.