### PR TITLE
convert log-entry into a bottom/side drawer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,8 @@ The app includes Progressive Web App features:
 ## Commit Messages
 
 - Never add `Co-Authored-By: Claude` or any AI attribution to commits
-- Keep messages short and lowercase
+- Keep messages short and lowercase; no long descriptions
+- When a commit resolves a GitHub issue, add `resolves #N` as the commit body (not in the subject line)
 
 ## Common Pitfalls
 

--- a/app/components/LogEntryDrawer.tsx
+++ b/app/components/LogEntryDrawer.tsx
@@ -1,0 +1,194 @@
+import { useState, useEffect, useCallback } from "react";
+import { CalendarBlank } from "@phosphor-icons/react";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from "~/components/ui/drawer";
+import { ScrollArea } from "~/components/ui/scroll-area";
+import { EntryInput } from "~/components/tracker/EntryInput";
+import { TrackerHistory } from "~/components/tracker/TrackerHistory";
+import { Separator } from "~/components/ui/separator";
+import { useIsMobile } from "~/lib/use-is-mobile";
+import { debouncedDataChange } from "~/lib/data-change-events";
+import {
+  getTrackerById,
+  getMostUsedTags,
+  getTotalValueForDate,
+  getEntryHistory,
+  createEntry,
+  deleteEntryById,
+  getDB,
+} from "~/lib/db";
+import type { Tracker } from "~/lib/trackers";
+import type { HistoryEntry } from "~/lib/history";
+
+type LogEntryDrawerProps = {
+  open: boolean;
+  onClose: () => void;
+  trackerId: string;
+  date: string;
+};
+
+type DrawerData = {
+  tracker: Tracker;
+  currentValue: number;
+  mostUsedTags: string[];
+  history: HistoryEntry[];
+};
+
+export function LogEntryDrawer({
+  open,
+  onClose,
+  trackerId,
+  date: initialDate,
+}: LogEntryDrawerProps) {
+  const isMobile = useIsMobile();
+  const [selectedDate, setSelectedDate] = useState(initialDate);
+  const [data, setData] = useState<DrawerData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [actionLoading, setActionLoading] = useState(false);
+  const [deletingEntryId, setDeletingEntryId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSelectedDate(initialDate);
+  }, [initialDate]);
+
+  const loadData = useCallback(async () => {
+    if (!open) return;
+    setLoading(true);
+    try {
+      const tracker = await getTrackerById(trackerId);
+      if (!tracker) return;
+      const [mostUsedTags, currentValue, allHistory] = await Promise.all([
+        getMostUsedTags(trackerId, 5),
+        getTotalValueForDate(trackerId, selectedDate),
+        getEntryHistory(trackerId),
+      ]);
+      const history = allHistory.filter((e) => e.date === selectedDate);
+      setData({ tracker, currentValue, mostUsedTags, history });
+    } finally {
+      setLoading(false);
+    }
+  }, [open, trackerId, selectedDate]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const handleQuickAdd = async (valueToAdd: number, comment?: string) => {
+    setActionLoading(true);
+    try {
+      await createEntry(trackerId, selectedDate, valueToAdd, false, false, comment);
+      debouncedDataChange.dispatch("entry_added", {
+        trackerId,
+        date: selectedDate,
+        value: valueToAdd,
+      });
+      await loadData();
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleCheckboxChange = async (checked: boolean, comment?: string) => {
+    setActionLoading(true);
+    try {
+      const db = await getDB();
+      const entries = await db.getAllFromIndex("entries", "by-tracker", trackerId);
+      const dateEntries = entries.filter((e) => e.date === selectedDate);
+      for (const entry of dateEntries) {
+        await deleteEntryById(entry.id);
+      }
+      if (checked) {
+        await createEntry(trackerId, selectedDate, 1, false, false, comment);
+      }
+      debouncedDataChange.dispatch("entry_updated", {
+        trackerId,
+        date: selectedDate,
+        value: checked ? 1 : 0,
+      });
+      await loadData();
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleDeleteEntry = async (entryId: string) => {
+    if (!confirm("Are you sure you want to delete this entry?")) return;
+    setDeletingEntryId(entryId);
+    try {
+      await deleteEntryById(entryId);
+      debouncedDataChange.dispatch("entry_deleted", { trackerId });
+      await loadData();
+    } finally {
+      setDeletingEntryId(null);
+    }
+  };
+
+  const direction = isMobile ? "bottom" : "right";
+
+  return (
+    <Drawer
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) onClose();
+      }}
+      direction={direction}
+    >
+      <DrawerContent>
+        <DrawerHeader className="border-b border-border">
+          <div className="flex items-center justify-between">
+            <DrawerTitle>{data?.tracker.title ?? "Log Entry"}</DrawerTitle>
+            <div className="flex items-center gap-2">
+              <CalendarBlank className="h-4 w-4 text-muted-foreground" />
+              <input
+                type="date"
+                value={selectedDate}
+                onChange={(e) => setSelectedDate(e.target.value)}
+                className="bg-transparent border border-input rounded px-2 py-1 text-sm"
+              />
+            </div>
+          </div>
+        </DrawerHeader>
+
+        <ScrollArea className="flex-1 overflow-auto">
+          <div className="p-4 flex flex-col gap-6">
+            {loading || !data ? (
+              <div className="text-sm text-muted-foreground py-8 text-center">
+                Loading…
+              </div>
+            ) : (
+              <>
+                <EntryInput
+                  tracker={data.tracker}
+                  currentValue={data.currentValue}
+                  selectedDate={selectedDate}
+                  onSubmit={handleQuickAdd}
+                  onCheckboxChange={handleCheckboxChange}
+                  mostUsedTags={data.mostUsedTags}
+                  entryLoading={actionLoading}
+                />
+
+                {data.history.length > 0 && (
+                  <>
+                    <Separator />
+                    <TrackerHistory
+                      history={data.history}
+                      tracker={data.tracker}
+                      onDeleteEntry={handleDeleteEntry}
+                      deletingEntryId={deletingEntryId}
+                      entryLoading={actionLoading}
+                      withoutStats
+                    />
+                  </>
+                )}
+              </>
+            )}
+          </div>
+        </ScrollArea>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/app/components/ui/drawer.tsx
+++ b/app/components/ui/drawer.tsx
@@ -1,0 +1,133 @@
+import * as React from "react"
+import { Drawer as DrawerPrimitive } from "vaul"
+
+import { cn } from "~/lib/utils"
+
+function Drawer({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+}
+
+function DrawerTrigger({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />
+}
+
+function DrawerPortal({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />
+}
+
+function DrawerClose({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPortal data-slot="drawer-portal">
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          "group/drawer-content fixed z-50 flex h-auto flex-col bg-background",
+          "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
+          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
+          "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
+          className
+        )}
+        {...props}
+      >
+        <div className="mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full bg-muted group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  )
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn(
+        "flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn("font-semibold text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+}

--- a/app/components/ui/drawer.tsx
+++ b/app/components/ui/drawer.tsx
@@ -54,7 +54,7 @@ function DrawerContent({
       <DrawerPrimitive.Content
         data-slot="drawer-content"
         className={cn(
-          "group/drawer-content fixed z-50 flex h-auto flex-col bg-background",
+          "group/drawer-content fixed z-50 flex h-auto flex-col bg-background outline-none",
           "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
           "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:h-[75vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
           "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",

--- a/app/components/ui/drawer.tsx
+++ b/app/components/ui/drawer.tsx
@@ -56,7 +56,7 @@ function DrawerContent({
         className={cn(
           "group/drawer-content fixed z-50 flex h-auto flex-col bg-background",
           "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
-          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
+          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:h-[75vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
           "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
           "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
           className

--- a/app/components/ui/drawer.tsx
+++ b/app/components/ui/drawer.tsx
@@ -35,7 +35,7 @@ function DrawerOverlay({
     <DrawerPrimitive.Overlay
       data-slot="drawer-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        "fixed inset-0 z-50 bg-black/70 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
         className
       )}
       {...props}

--- a/app/lib/hooks/useLogEntryDrawer.ts
+++ b/app/lib/hooks/useLogEntryDrawer.ts
@@ -1,0 +1,26 @@
+import { useState } from "react";
+
+type LogEntryDrawerState = {
+  open: boolean;
+  trackerId: string;
+  date: string;
+};
+
+const CLOSED: LogEntryDrawerState = { open: false, trackerId: "", date: "" };
+
+export function useLogEntryDrawer(onCloseUrl: string | (() => string)) {
+  const [state, setState] = useState<LogEntryDrawerState>(CLOSED);
+
+  const openLogEntry = (trackerId: string, date: string) => {
+    setState({ open: true, trackerId, date });
+    window.history.pushState(null, "", `/t/${trackerId}/log-entry?date=${date}`);
+  };
+
+  const closeLogEntry = () => {
+    setState((prev) => ({ ...prev, open: false }));
+    const url = typeof onCloseUrl === "function" ? onCloseUrl() : onCloseUrl;
+    window.history.replaceState(null, "", url);
+  };
+
+  return { state, openLogEntry, closeLogEntry };
+}

--- a/app/lib/use-is-mobile.ts
+++ b/app/lib/use-is-mobile.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(
+    () => window.innerWidth < MOBILE_BREAKPOINT
+  );
+
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const onChange = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+
+  return isMobile;
+}

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,7 +1,8 @@
 import { addDays, format } from "date-fns";
 import { ChartBar, Check, CaretDown, CaretLeft, CaretRight, Tree, Plus, Gear } from "@phosphor-icons/react";
 import { useState, useEffect } from "react";
-import { Link, redirect, useLoaderData, useNavigate } from "react-router";
+import { Link, redirect, useLoaderData } from "react-router";
+import { LogEntryDrawer } from "~/components/LogEntryDrawer";
 import { Button } from "~/components/ui/button";
 import { Separator } from "~/components/ui/separator";
 import { formatDateForDisplay, getDaysArray, isDateToday } from "~/lib/dates";
@@ -60,7 +61,6 @@ export function meta() {
 export default function Home() {
   const { trackers, savedExpandedTrackers } =
     useLoaderData<typeof clientLoader>();
-  const navigate = useNavigate();
   const [currentLastDate, setCurrentLastDate] = useState(() => new Date());
   const [showHiddenTrackers, setShowHiddenTrackers] = useState(() =>
     getShowHiddenTrackers()
@@ -68,6 +68,21 @@ export default function Home() {
   const [expandedTrackers, setExpandedTrackers] = useState<Set<string>>(
     () => new Set(savedExpandedTrackers)
   );
+  const [drawerState, setDrawerState] = useState<{
+    open: boolean;
+    trackerId: string;
+    date: string;
+  }>({ open: false, trackerId: "", date: "" });
+
+  const openDrawer = (trackerId: string, date: string) => {
+    setDrawerState({ open: true, trackerId, date });
+    window.history.pushState(null, "", `/t/${trackerId}/log-entry?date=${date}`);
+  };
+
+  const closeDrawer = () => {
+    setDrawerState((prev) => ({ ...prev, open: false }));
+    window.history.replaceState(null, "", "/");
+  };
 
   // TODO: Investigate why this is necessary
   useEffect(() => {
@@ -347,7 +362,7 @@ export default function Home() {
                             )}
                           <button
                             type="button"
-                            onClick={() => navigate(`/t/${tracker.id}/log-entry?date=${dateString}`)}
+                            onClick={() => openDrawer(tracker.id, dateString)}
                             className="absolute inset-0 cursor-pointer"
                             aria-label={`Log entry for ${tracker.title}`}
                           />
@@ -372,6 +387,14 @@ export default function Home() {
         </div>
       )}
 
+      {drawerState.trackerId && (
+        <LogEntryDrawer
+          open={drawerState.open}
+          onClose={closeDrawer}
+          trackerId={drawerState.trackerId}
+          date={drawerState.date}
+        />
+      )}
     </div>
   );
 }

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -2,6 +2,7 @@ import { addDays, format } from "date-fns";
 import { ChartBar, Check, CaretDown, CaretLeft, CaretRight, Tree, Plus, Gear } from "@phosphor-icons/react";
 import { useState, useEffect } from "react";
 import { Link, redirect, useLoaderData } from "react-router";
+import { LogEntryDrawer } from "~/components/LogEntryDrawer";
 import { Button } from "~/components/ui/button";
 import { Separator } from "~/components/ui/separator";
 import { formatDateForDisplay, getDaysArray, isDateToday } from "~/lib/dates";
@@ -67,6 +68,19 @@ export default function Home() {
   const [expandedTrackers, setExpandedTrackers] = useState<Set<string>>(
     () => new Set(savedExpandedTrackers)
   );
+  const [drawerState, setDrawerState] = useState<{
+    open: boolean;
+    trackerId: string;
+    date: string;
+  }>({ open: false, trackerId: "", date: "" });
+
+  const openDrawer = (trackerId: string, date: string) => {
+    setDrawerState({ open: true, trackerId, date });
+  };
+
+  const closeDrawer = () => {
+    setDrawerState((prev) => ({ ...prev, open: false }));
+  };
 
   // TODO: Investigate why this is necessary
   useEffect(() => {
@@ -344,11 +358,11 @@ export default function Home() {
                                 {trackerTypesLabels[tracker.type].short}
                               </span>
                             )}
-                          <Link
-                            to={`/t/${tracker.id}/log-entry?date=${dateString}`}
-                            prefetch="viewport"
-                            className="absolute inset-0"
-                            aria-label={`Open ${tracker.title} tracker`}
+                          <button
+                            type="button"
+                            onClick={() => openDrawer(tracker.id, dateString)}
+                            className="absolute inset-0 cursor-pointer"
+                            aria-label={`Log entry for ${tracker.title}`}
                           />
                         </div>
                       );
@@ -369,6 +383,15 @@ export default function Home() {
             </Link>
           </Button>
         </div>
+      )}
+
+      {drawerState.trackerId && (
+        <LogEntryDrawer
+          open={drawerState.open}
+          onClose={closeDrawer}
+          trackerId={drawerState.trackerId}
+          date={drawerState.date}
+        />
       )}
     </div>
   );

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,7 +1,7 @@
 import { addDays, format } from "date-fns";
 import { ChartBar, Check, CaretDown, CaretLeft, CaretRight, Tree, Plus, Gear } from "@phosphor-icons/react";
 import { useState, useEffect } from "react";
-import { Link, redirect, useLoaderData, useLocation, useNavigate } from "react-router";
+import { Link, redirect, useLoaderData, useLocation } from "react-router";
 import { LogEntryDrawer } from "~/components/LogEntryDrawer";
 import { useLogEntryDrawer } from "~/lib/hooks/useLogEntryDrawer";
 import { Button } from "~/components/ui/button";
@@ -71,14 +71,14 @@ export default function Home() {
   );
   const { state: logEntryDrawer, openLogEntry, closeLogEntry } = useLogEntryDrawer("/");
   const location = useLocation();
-  const navigate = useNavigate();
 
   useEffect(() => {
     const pending = (location.state as { openLogEntry?: { trackerId: string; date: string } } | null)
       ?.openLogEntry;
     if (pending) {
       openLogEntry(pending.trackerId, pending.date);
-      navigate(".", { replace: true, state: {} });
+      // Clear state without triggering React Router navigation (avoid /?index)
+      window.history.replaceState({ ...window.history.state, usr: null }, "");
     }
   }, []);
 

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,8 +1,7 @@
 import { addDays, format } from "date-fns";
 import { ChartBar, Check, CaretDown, CaretLeft, CaretRight, Tree, Plus, Gear } from "@phosphor-icons/react";
 import { useState, useEffect } from "react";
-import { Link, redirect, useLoaderData } from "react-router";
-import { LogEntryDrawer } from "~/components/LogEntryDrawer";
+import { Link, redirect, useLoaderData, useNavigate } from "react-router";
 import { Button } from "~/components/ui/button";
 import { Separator } from "~/components/ui/separator";
 import { formatDateForDisplay, getDaysArray, isDateToday } from "~/lib/dates";
@@ -61,6 +60,7 @@ export function meta() {
 export default function Home() {
   const { trackers, savedExpandedTrackers } =
     useLoaderData<typeof clientLoader>();
+  const navigate = useNavigate();
   const [currentLastDate, setCurrentLastDate] = useState(() => new Date());
   const [showHiddenTrackers, setShowHiddenTrackers] = useState(() =>
     getShowHiddenTrackers()
@@ -68,19 +68,6 @@ export default function Home() {
   const [expandedTrackers, setExpandedTrackers] = useState<Set<string>>(
     () => new Set(savedExpandedTrackers)
   );
-  const [drawerState, setDrawerState] = useState<{
-    open: boolean;
-    trackerId: string;
-    date: string;
-  }>({ open: false, trackerId: "", date: "" });
-
-  const openDrawer = (trackerId: string, date: string) => {
-    setDrawerState({ open: true, trackerId, date });
-  };
-
-  const closeDrawer = () => {
-    setDrawerState((prev) => ({ ...prev, open: false }));
-  };
 
   // TODO: Investigate why this is necessary
   useEffect(() => {
@@ -360,7 +347,7 @@ export default function Home() {
                             )}
                           <button
                             type="button"
-                            onClick={() => openDrawer(tracker.id, dateString)}
+                            onClick={() => navigate(`/t/${tracker.id}/log-entry?date=${dateString}`)}
                             className="absolute inset-0 cursor-pointer"
                             aria-label={`Log entry for ${tracker.title}`}
                           />
@@ -385,14 +372,6 @@ export default function Home() {
         </div>
       )}
 
-      {drawerState.trackerId && (
-        <LogEntryDrawer
-          open={drawerState.open}
-          onClose={closeDrawer}
-          trackerId={drawerState.trackerId}
-          date={drawerState.date}
-        />
-      )}
     </div>
   );
 }

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,7 +1,7 @@
 import { addDays, format } from "date-fns";
 import { ChartBar, Check, CaretDown, CaretLeft, CaretRight, Tree, Plus, Gear } from "@phosphor-icons/react";
 import { useState, useEffect } from "react";
-import { Link, redirect, useLoaderData } from "react-router";
+import { Link, redirect, useLoaderData, useLocation, useNavigate } from "react-router";
 import { LogEntryDrawer } from "~/components/LogEntryDrawer";
 import { useLogEntryDrawer } from "~/lib/hooks/useLogEntryDrawer";
 import { Button } from "~/components/ui/button";
@@ -70,6 +70,17 @@ export default function Home() {
     () => new Set(savedExpandedTrackers)
   );
   const { state: logEntryDrawer, openLogEntry, closeLogEntry } = useLogEntryDrawer("/");
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const pending = (location.state as { openLogEntry?: { trackerId: string; date: string } } | null)
+      ?.openLogEntry;
+    if (pending) {
+      openLogEntry(pending.trackerId, pending.date);
+      navigate(".", { replace: true, state: {} });
+    }
+  }, []);
 
   // TODO: Investigate why this is necessary
   useEffect(() => {

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -3,6 +3,7 @@ import { ChartBar, Check, CaretDown, CaretLeft, CaretRight, Tree, Plus, Gear } f
 import { useState, useEffect } from "react";
 import { Link, redirect, useLoaderData } from "react-router";
 import { LogEntryDrawer } from "~/components/LogEntryDrawer";
+import { useLogEntryDrawer } from "~/lib/hooks/useLogEntryDrawer";
 import { Button } from "~/components/ui/button";
 import { Separator } from "~/components/ui/separator";
 import { formatDateForDisplay, getDaysArray, isDateToday } from "~/lib/dates";
@@ -68,21 +69,7 @@ export default function Home() {
   const [expandedTrackers, setExpandedTrackers] = useState<Set<string>>(
     () => new Set(savedExpandedTrackers)
   );
-  const [drawerState, setDrawerState] = useState<{
-    open: boolean;
-    trackerId: string;
-    date: string;
-  }>({ open: false, trackerId: "", date: "" });
-
-  const openDrawer = (trackerId: string, date: string) => {
-    setDrawerState({ open: true, trackerId, date });
-    window.history.pushState(null, "", `/t/${trackerId}/log-entry?date=${date}`);
-  };
-
-  const closeDrawer = () => {
-    setDrawerState((prev) => ({ ...prev, open: false }));
-    window.history.replaceState(null, "", "/");
-  };
+  const { state: logEntryDrawer, openLogEntry, closeLogEntry } = useLogEntryDrawer("/");
 
   // TODO: Investigate why this is necessary
   useEffect(() => {
@@ -362,7 +349,7 @@ export default function Home() {
                             )}
                           <button
                             type="button"
-                            onClick={() => openDrawer(tracker.id, dateString)}
+                            onClick={() => openLogEntry(tracker.id, dateString)}
                             className="absolute inset-0 cursor-pointer"
                             aria-label={`Log entry for ${tracker.title}`}
                           />
@@ -387,12 +374,12 @@ export default function Home() {
         </div>
       )}
 
-      {drawerState.trackerId && (
+      {logEntryDrawer.trackerId && (
         <LogEntryDrawer
-          open={drawerState.open}
-          onClose={closeDrawer}
-          trackerId={drawerState.trackerId}
-          date={drawerState.date}
+          open={logEntryDrawer.open}
+          onClose={closeLogEntry}
+          trackerId={logEntryDrawer.trackerId}
+          date={logEntryDrawer.date}
         />
       )}
     </div>

--- a/app/routes/t.$trackerId.(layout).tsx
+++ b/app/routes/t.$trackerId.(layout).tsx
@@ -1,14 +1,15 @@
 import { CaretLeft } from "@phosphor-icons/react";
+import { useState } from "react";
 import {
   Link,
   Outlet,
   useLoaderData,
-  useNavigate,
   useParams,
   type ClientLoaderFunctionArgs,
 } from "react-router";
 import { Button } from "~/components/ui/button";
 import TabsNavigation from "~/components/ui/tabs-navigation";
+import { LogEntryDrawer } from "~/components/LogEntryDrawer";
 import { getTrackerById } from "~/lib/db";
 import { formatDateString } from "~/lib/dates";
 
@@ -32,7 +33,17 @@ export async function clientLoader({ params }: ClientLoaderFunctionArgs) {
 export default function TrackerPageLayout() {
   const { trackerId } = useParams();
   const { tracker } = useLoaderData<typeof clientLoader>();
-  const navigate = useNavigate();
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const openDrawer = () => {
+    setDrawerOpen(true);
+    window.history.pushState(null, "", `/t/${trackerId}/log-entry`);
+  };
+
+  const closeDrawer = () => {
+    setDrawerOpen(false);
+    window.history.replaceState(null, "", `/t/${trackerId}/history`);
+  };
 
   return (
     <>
@@ -45,10 +56,7 @@ export default function TrackerPageLayout() {
           </Button>
           <span className="font-medium">{tracker.title}</span>
         </div>
-        <Button
-          variant="secondary"
-          onClick={() => navigate(`/t/${trackerId}/log-entry`)}
-        >
+        <Button variant="secondary" onClick={openDrawer}>
           Log new entry
         </Button>
       </div>
@@ -70,6 +78,15 @@ export default function TrackerPageLayout() {
         ]}
       />
       <Outlet />
+
+      {trackerId && (
+        <LogEntryDrawer
+          open={drawerOpen}
+          onClose={closeDrawer}
+          trackerId={trackerId}
+          date={formatDateString(new Date())}
+        />
+      )}
     </>
   );
 }

--- a/app/routes/t.$trackerId.(layout).tsx
+++ b/app/routes/t.$trackerId.(layout).tsx
@@ -1,15 +1,14 @@
 import { CaretLeft } from "@phosphor-icons/react";
-import { useState } from "react";
 import {
   Link,
   Outlet,
   useLoaderData,
+  useNavigate,
   useParams,
   type ClientLoaderFunctionArgs,
 } from "react-router";
 import { Button } from "~/components/ui/button";
 import TabsNavigation from "~/components/ui/tabs-navigation";
-import { LogEntryDrawer } from "~/components/LogEntryDrawer";
 import { getTrackerById } from "~/lib/db";
 import { formatDateString } from "~/lib/dates";
 
@@ -33,7 +32,7 @@ export async function clientLoader({ params }: ClientLoaderFunctionArgs) {
 export default function TrackerPageLayout() {
   const { trackerId } = useParams();
   const { tracker } = useLoaderData<typeof clientLoader>();
-  const [drawerOpen, setDrawerOpen] = useState(false);
+  const navigate = useNavigate();
 
   return (
     <>
@@ -46,7 +45,10 @@ export default function TrackerPageLayout() {
           </Button>
           <span className="font-medium">{tracker.title}</span>
         </div>
-        <Button variant="secondary" onClick={() => setDrawerOpen(true)}>
+        <Button
+          variant="secondary"
+          onClick={() => navigate(`/t/${trackerId}/log-entry`)}
+        >
           Log new entry
         </Button>
       </div>
@@ -68,15 +70,6 @@ export default function TrackerPageLayout() {
         ]}
       />
       <Outlet />
-
-      {trackerId && (
-        <LogEntryDrawer
-          open={drawerOpen}
-          onClose={() => setDrawerOpen(false)}
-          trackerId={trackerId}
-          date={formatDateString(new Date())}
-        />
-      )}
     </>
   );
 }

--- a/app/routes/t.$trackerId.(layout).tsx
+++ b/app/routes/t.$trackerId.(layout).tsx
@@ -1,5 +1,4 @@
 import { CaretLeft } from "@phosphor-icons/react";
-import { useState } from "react";
 import {
   Link,
   Outlet,
@@ -12,6 +11,7 @@ import TabsNavigation from "~/components/ui/tabs-navigation";
 import { LogEntryDrawer } from "~/components/LogEntryDrawer";
 import { getTrackerById } from "~/lib/db";
 import { formatDateString } from "~/lib/dates";
+import { useLogEntryDrawer } from "~/lib/hooks/useLogEntryDrawer";
 
 export async function clientLoader({ params }: ClientLoaderFunctionArgs) {
   const trackerId = params.trackerId;
@@ -33,17 +33,9 @@ export async function clientLoader({ params }: ClientLoaderFunctionArgs) {
 export default function TrackerPageLayout() {
   const { trackerId } = useParams();
   const { tracker } = useLoaderData<typeof clientLoader>();
-  const [drawerOpen, setDrawerOpen] = useState(false);
-
-  const openDrawer = () => {
-    setDrawerOpen(true);
-    window.history.pushState(null, "", `/t/${trackerId}/log-entry`);
-  };
-
-  const closeDrawer = () => {
-    setDrawerOpen(false);
-    window.history.replaceState(null, "", `/t/${trackerId}/history`);
-  };
+  const { state: logEntryDrawer, openLogEntry, closeLogEntry } = useLogEntryDrawer(
+    () => `/t/${trackerId}/history`
+  );
 
   return (
     <>
@@ -56,7 +48,7 @@ export default function TrackerPageLayout() {
           </Button>
           <span className="font-medium">{tracker.title}</span>
         </div>
-        <Button variant="secondary" onClick={openDrawer}>
+        <Button variant="secondary" onClick={() => openLogEntry(trackerId!, formatDateString(new Date()))}>
           Log new entry
         </Button>
       </div>
@@ -79,12 +71,12 @@ export default function TrackerPageLayout() {
       />
       <Outlet />
 
-      {trackerId && (
+      {logEntryDrawer.trackerId && (
         <LogEntryDrawer
-          open={drawerOpen}
-          onClose={closeDrawer}
-          trackerId={trackerId}
-          date={formatDateString(new Date())}
+          open={logEntryDrawer.open}
+          onClose={closeLogEntry}
+          trackerId={logEntryDrawer.trackerId}
+          date={logEntryDrawer.date}
         />
       )}
     </>

--- a/app/routes/t.$trackerId.(layout).tsx
+++ b/app/routes/t.$trackerId.(layout).tsx
@@ -1,4 +1,5 @@
 import { CaretLeft } from "@phosphor-icons/react";
+import { useState } from "react";
 import {
   Link,
   Outlet,
@@ -8,7 +9,9 @@ import {
 } from "react-router";
 import { Button } from "~/components/ui/button";
 import TabsNavigation from "~/components/ui/tabs-navigation";
+import { LogEntryDrawer } from "~/components/LogEntryDrawer";
 import { getTrackerById } from "~/lib/db";
+import { formatDateString } from "~/lib/dates";
 
 export async function clientLoader({ params }: ClientLoaderFunctionArgs) {
   const trackerId = params.trackerId;
@@ -30,6 +33,7 @@ export async function clientLoader({ params }: ClientLoaderFunctionArgs) {
 export default function TrackerPageLayout() {
   const { trackerId } = useParams();
   const { tracker } = useLoaderData<typeof clientLoader>();
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   return (
     <>
@@ -42,8 +46,8 @@ export default function TrackerPageLayout() {
           </Button>
           <span className="font-medium">{tracker.title}</span>
         </div>
-        <Button asChild variant="secondary">
-          <Link to={`/t/${trackerId}/log-entry`}>Log new entry</Link>
+        <Button variant="secondary" onClick={() => setDrawerOpen(true)}>
+          Log new entry
         </Button>
       </div>
       <TabsNavigation
@@ -64,6 +68,15 @@ export default function TrackerPageLayout() {
         ]}
       />
       <Outlet />
+
+      {trackerId && (
+        <LogEntryDrawer
+          open={drawerOpen}
+          onClose={() => setDrawerOpen(false)}
+          trackerId={trackerId}
+          date={formatDateString(new Date())}
+        />
+      )}
     </>
   );
 }

--- a/app/routes/t.$trackerId.log-entry.tsx
+++ b/app/routes/t.$trackerId.log-entry.tsx
@@ -1,35 +1,9 @@
-import { useState, useEffect } from "react";
-import {
-  useLoaderData,
-  useSubmit,
-  useNavigation,
-  useNavigate,
-} from "react-router";
-import type {
-  ClientLoaderFunctionArgs,
-  ClientActionFunctionArgs,
-} from "react-router";
+import { useLoaderData, useNavigate } from "react-router";
+import type { ClientLoaderFunctionArgs } from "react-router";
 import { formatDateString } from "~/lib/dates";
-import {
-  getTrackerById,
-  getMostUsedTags,
-  createEntry,
-  getTotalValueForDate,
-  getDB,
-  deleteEntryById,
-  getEntryHistory,
-} from "~/lib/db";
-import { debouncedDataChange } from "~/lib/data-change-events";
-import {
-  TrackerHeader,
-  EntryInput,
-  TrackerHistory,
-} from "~/components/tracker";
+import { LogEntryDrawer } from "~/components/LogEntryDrawer";
 
-export async function clientLoader({
-  params,
-  request,
-}: ClientLoaderFunctionArgs) {
+export async function clientLoader({ params, request }: ClientLoaderFunctionArgs) {
   const trackerId = params.trackerId;
   if (!trackerId) {
     throw new Response("Tracker ID is required", { status: 400 });
@@ -39,88 +13,10 @@ export async function clientLoader({
   const dateParam = url.searchParams.get("date");
   const selectedDate = dateParam || formatDateString(new Date());
 
-  try {
-    const tracker = await getTrackerById(trackerId);
-    if (!tracker) {
-      throw new Response("Tracker not found", { status: 404 });
-    }
-
-    const mostUsedTags = await getMostUsedTags(trackerId, 5);
-    const currentValue = await getTotalValueForDate(trackerId, selectedDate);
-    const allHistory = await getEntryHistory(trackerId);
-
-    // Filter history to only entries for the selected date
-    const history = allHistory.filter((entry) => entry.date === selectedDate);
-
-    return { tracker, currentValue, selectedDate, mostUsedTags, history };
-  } catch (error) {
-    throw new Response("Failed to load tracker", { status: 500 });
-  }
+  return { trackerId, selectedDate };
 }
 
-export async function clientAction({
-  params,
-  request,
-}: ClientActionFunctionArgs) {
-  const trackerId = params.trackerId;
-  if (!trackerId) {
-    throw new Response("Tracker ID is required", { status: 400 });
-  }
-
-  const formData = await request.formData();
-  const intent = formData.get("intent");
-  const date = (formData.get("date") as string) || formatDateString(new Date());
-  const comment = (formData.get("comment") as string) || undefined;
-
-  try {
-    if (intent === "addValue") {
-      const valueToAdd = parseInt(formData.get("value") as string);
-      if (!isNaN(valueToAdd)) {
-        await createEntry(trackerId, date, valueToAdd, false, false, comment);
-        debouncedDataChange.dispatch("entry_added", {
-          trackerId,
-          date,
-          value: valueToAdd,
-        });
-      }
-    } else if (intent === "setCheckbox") {
-      const checked = formData.get("checked") === "true";
-      const value = checked ? 1 : 0;
-
-      // Delete all existing entries for this date
-      const db = await getDB();
-      const entries = await db.getAllFromIndex(
-        "entries",
-        "by-tracker",
-        trackerId
-      );
-      const dateEntries = entries.filter((entry) => entry.date === date);
-      for (const entry of dateEntries) {
-        await deleteEntryById(entry.id);
-      }
-
-      // Create new entry if checked
-      if (value > 0) {
-        await createEntry(trackerId, date, value, false, false, comment);
-      }
-
-      debouncedDataChange.dispatch("entry_updated", { trackerId, date, value });
-    } else if (intent === "deleteEntry") {
-      const entryId = formData.get("entryId") as string;
-      if (entryId) {
-        await deleteEntryById(entryId);
-        debouncedDataChange.dispatch("entry_deleted", { trackerId });
-      }
-    }
-
-    return { success: true };
-  } catch (error) {
-    console.error("Failed to perform action:", error);
-    return { success: false, error: "Failed to update entry" };
-  }
-}
-
-export function meta({ params }: { params: { trackerId: string } }) {
+export function meta() {
   return [
     { title: "Log Entry - AnythingTracker" },
     {
@@ -132,105 +28,15 @@ export function meta({ params }: { params: { trackerId: string } }) {
 }
 
 export default function LogEntryPage() {
-  const navigation = useNavigation();
+  const { trackerId, selectedDate } = useLoaderData<typeof clientLoader>();
   const navigate = useNavigate();
-  const submit = useSubmit();
-  const {
-    tracker,
-    mostUsedTags,
-    currentValue: loaderCurrentValue,
-    selectedDate,
-    history,
-  } = useLoaderData<typeof clientLoader>();
-
-  const [deletingEntryId, setDeletingEntryId] = useState<string | null>(null);
-  const isLoading = navigation.state !== "idle";
-
-  const handleDateChange = (newDate: string) => {
-    navigate(`?date=${newDate}`, { replace: true });
-  };
-
-  const handleQuickAdd = async (valueToAdd: number, comment?: string) => {
-    const formData = new FormData();
-    formData.append("intent", "addValue");
-    formData.append("value", valueToAdd.toString());
-    formData.append("date", selectedDate);
-    if (comment) {
-      formData.append("comment", comment);
-    }
-
-    submit(formData, { method: "post" });
-  };
-
-  const handleCheckboxChange = async (checked: boolean, comment?: string) => {
-    const formData = new FormData();
-    formData.append("intent", "setCheckbox");
-    formData.append("checked", checked.toString());
-    formData.append("date", selectedDate);
-    if (comment) {
-      formData.append("comment", comment);
-    }
-
-    submit(formData, { method: "post" });
-  };
-
-  const handleDeleteEntry = async (entryId: string) => {
-    if (!confirm("Are you sure you want to delete this entry?")) {
-      return;
-    }
-
-    setDeletingEntryId(entryId);
-
-    const formData = new FormData();
-    formData.append("intent", "deleteEntry");
-    formData.append("entryId", entryId);
-
-    submit(formData, { method: "post" });
-  };
-
-  // Clear deletingEntryId when navigation is complete
-  useEffect(() => {
-    if (navigation.state === "idle") {
-      setDeletingEntryId(null);
-    }
-  }, [navigation.state]);
-
-  if (!tracker) {
-    return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-destructive">Tracker not found</div>
-      </div>
-    );
-  }
 
   return (
-    <div className="grid gap-8">
-      <TrackerHeader
-        trackerTitle={tracker.title}
-        selectedDate={selectedDate}
-        onDateChange={handleDateChange}
-      />
-
-      <EntryInput
-        tracker={tracker}
-        currentValue={loaderCurrentValue}
-        selectedDate={selectedDate}
-        onSubmit={handleQuickAdd}
-        onCheckboxChange={handleCheckboxChange}
-        mostUsedTags={mostUsedTags}
-        entryLoading={isLoading}
-      />
-
-      {!!history.length && (
-        <TrackerHistory
-          history={history}
-          tracker={tracker}
-          onDeleteEntry={handleDeleteEntry}
-          deletingEntryId={deletingEntryId}
-          entryLoading={isLoading}
-          withoutStats
-        />
-      )}
-    </div>
+    <LogEntryDrawer
+      open={true}
+      onClose={() => navigate(-1)}
+      trackerId={trackerId}
+      date={selectedDate}
+    />
   );
 }

--- a/app/routes/t.$trackerId.log-entry.tsx
+++ b/app/routes/t.$trackerId.log-entry.tsx
@@ -1,7 +1,7 @@
+import { useEffect } from "react";
 import { useLoaderData, useNavigate } from "react-router";
 import type { ClientLoaderFunctionArgs } from "react-router";
 import { formatDateString } from "~/lib/dates";
-import { LogEntryDrawer } from "~/components/LogEntryDrawer";
 
 export async function clientLoader({ params, request }: ClientLoaderFunctionArgs) {
   const trackerId = params.trackerId;
@@ -31,12 +31,12 @@ export default function LogEntryPage() {
   const { trackerId, selectedDate } = useLoaderData<typeof clientLoader>();
   const navigate = useNavigate();
 
-  return (
-    <LogEntryDrawer
-      open={true}
-      onClose={() => navigate(-1)}
-      trackerId={trackerId}
-      date={selectedDate}
-    />
-  );
+  useEffect(() => {
+    navigate("/", {
+      replace: true,
+      state: { openLogEntry: { trackerId, date: selectedDate } },
+    });
+  }, []);
+
+  return null;
 }

--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
         "react-router": "^7.9.4",
         "recharts": "2.15.4",
         "tailwind-merge": "^3.3.1",
+        "vaul": "^1.1.2",
         "zustand": "^5.0.8",
       },
       "devDependencies": {
@@ -839,6 +840,8 @@
     "valibot": ["valibot@1.2.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "vaul": ["vaul@1.1.2", "", { "dependencies": { "@radix-ui/react-dialog": "^1.1.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA=="],
 
     "victory-vendor": ["victory-vendor@36.9.2", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ=="],
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-router": "^7.9.4",
     "recharts": "2.15.4",
     "tailwind-merge": "^3.3.1",
+    "vaul": "^1.1.2",
     "zustand": "^5.0.8"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Install `vaul`; add shadcn `Drawer` component via CLI
- Add `useIsMobile` hook — bottom drawer on mobile, right panel on desktop
- Create `LogEntryDrawer` component that loads data directly from IndexedDB
- Home grid cells open the drawer instead of navigating to `/log-entry`
- Tracker layout "Log new entry" button opens the drawer
- `/t/:id/log-entry` route kept for deep-linking; renders drawer auto-opened

## Test plan
- [x] Tap a grid cell on the home page → drawer opens with correct tracker + date
- [x] "Log new entry" in tracker detail header → drawer opens with today's date
- [x] Navigate to `/t/<id>/log-entry` directly → drawer opens, close navigates back
- [x] On desktop (≥768px) → drawer slides from the right
- [x] On mobile (<768px) → drawer slides from the bottom
- [x] Adding/deleting entries inside drawer updates the home grid without a full page reload

Closes #85